### PR TITLE
#155 docker metrics now accessible on static local docker ip (172.17.…

### DIFF
--- a/minitwit/prometheus.yml
+++ b/minitwit/prometheus.yml
@@ -27,3 +27,10 @@ scrape_configs:
       - targets: ['dotnet_backend']
         labels:
           group: 'production'
+
+  - job_name: 'docker'
+
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['172.17.0.1:9323']


### PR DESCRIPTION
…0.1) , port 9323