### PR TITLE
apparantly, on each pull, permissions for run_script.sh are reset. so…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,5 +82,6 @@ jobs:
               echo "${{ secrets.DB_CONNECTION_STRING }}" > .local/connection_string.txt  &&
               echo "${{ secrets.JWT_KEY }}" > .local/jwt_key.txt  &&
               htpasswd -b -c .local/.htpasswd ${{ secrets.KIBANA_USER }} "${{ secrets.KIBANA_PW }}" &&
+              chmod +x run_script.sh && 
               ./run_script.sh &&
               echo "BIG CLAPS GJ Friends"


### PR DESCRIPTION
… in our deploy script we need to chmod it